### PR TITLE
remove node-cache dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "cheerio": "^1.0.0-rc.12",
-    "node-cache": "^5.1.2",
     "genkit": "^1.0.0",
     "zod": "^3.23.8",
     "@google-ai/genkit": "^1.0.0",

--- a/src/ai/util/cache.ts
+++ b/src/ai/util/cache.ts
@@ -1,16 +1,23 @@
-import NodeCache from 'node-cache';
+// A minimal in-memory cache to avoid the `node-cache` dependency which cannot
+// be installed in some restricted environments. This mirrors the behaviour of
+// the original cache with a fixed TTL of one hour.
+
 import type { ConsentFormCategory } from '@/lib/types';
 
-// stdTTL: time-to-live in seconds for every new entry. 0 = unlimited.
-// checkperiod: The period in seconds, as a number, used for the automatic delete check interval.
-const cache = new NodeCache({ stdTTL: 3600, checkperiod: 600 });
+const ONE_HOUR_MS = 60 * 60 * 1000;
 
-const CACHE_KEY = 'consentForms';
+let cachedData: ConsentFormCategory[] | undefined;
+let cacheExpiry = 0;
 
 export function getCachedForms(): ConsentFormCategory[] | undefined {
-  return cache.get<ConsentFormCategory[]>(CACHE_KEY);
+  if (cacheExpiry > Date.now()) {
+    return cachedData;
+  }
+  return undefined;
 }
 
 export function updateCache(data: ConsentFormCategory[]): boolean {
-  return cache.set(CACHE_KEY, data);
+  cachedData = data;
+  cacheExpiry = Date.now() + ONE_HOUR_MS;
+  return true;
 }


### PR DESCRIPTION
## Summary
- replace `node-cache` with a simple in-memory cache since modules can't be installed
- drop `node-cache` from dependencies

## Testing
- `npm run typecheck` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_687a59c636508324a6d4535257625136