### PR TITLE
Fix patient name field mapping in PDF flow

### DIFF
--- a/src/ai/flows/fill-pdf-flow.ts
+++ b/src/ai/flows/fill-pdf-flow.ts
@@ -61,7 +61,7 @@ export async function fillPdf(input: FillPdfInput): Promise<FillPdfOutput> {
     const fieldMapping: { [key: string]: string[] } = {
         fullName: ['Patient Name', 'Name of patient', 'Patient full name', 'topmostSubform[0].Page1[0].p1-f1-1[0]', 'Patient name'],
         forename: ['First name(s)', 'Forename', 'Patient’s first name'],
-        surname: ['Last name', 'Patient’s last name', 'Surname', 'Patient name'],
+        surname: ['Last name', 'Patient’s last name', 'Surname'],
         dob: ['Date of birth', 'Patient’s date of birth (DD/MM/YYYY)'],
         hospitalNumber: ['Hospital Number', 'Patient’s hospital number'],
         hospitalNumberMTW: ['Hospital Number MTW'],


### PR DESCRIPTION
## Summary
- ensure the `Patient name` field is filled with the full patient name

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_688a3f8e76848324996bc96c64d836d4