### PR TITLE
Fix PDF full name mapping

### DIFF
--- a/src/ai/flows/fill-pdf-flow.ts
+++ b/src/ai/flows/fill-pdf-flow.ts
@@ -62,6 +62,7 @@ export async function fillPdf(input: FillPdfInput): Promise<FillPdfOutput> {
         fullName: [
           'Patient Name',
           'Patient name',
+          'Patient name:',
           'Patients Name',
           "Patient's Name",
           'PatientName',


### PR DESCRIPTION
## Summary
- ensure `fullName` field matches forms labelled as `Patient name:`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a430953a08324a357ae4384c9e327