### PR TITLE
Add basic Node tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ next-env.d.ts
 
 # Temporary files
 /tmp
+test-dist

--- a/README.md
+++ b/README.md
@@ -97,3 +97,8 @@ This is the most complex part of the application. A key design principle is that
     -   This flow uses `pdf-lib` to fill the original PDF with the final data.
     -   The filled PDF is saved to a temporary file in the `/tmp` directory, and its unique ID is returned to the client.
     -   The client then opens a new tab pointing to an API route (`/api/filled-pdf/[id]`), which serves the generated PDF for viewing and printing.
+
+## Running Tests
+
+Run `npm test` to compile a few TypeScript flows and execute the sample tests using Node's built-in test runner.
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "pretest": "tsc -p tsconfig.test.json",
+    "test": "NODE_PATH=test-dist node --test",
+    "posttest": "rm -rf test-dist"
   },
   "dependencies": {
     "@hookform/resolvers": "^4.1.3",

--- a/tests/get-pdf-fields.test.js
+++ b/tests/get-pdf-fields.test.js
@@ -1,0 +1,19 @@
+import "./setup.js";
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PDFDocument } from 'pdf-lib';
+import { getPdfFields } from '../test-dist/ai/flows/get-pdf-fields-flow.js';
+
+test('getPdfFields returns text field names only', async () => {
+  const pdfDoc = await PDFDocument.create();
+  const form = pdfDoc.getForm();
+  form.createTextField('patient_name');
+  form.createCheckBox('agree');
+  const pdfBytes = await pdfDoc.save();
+
+  global.fetch = async () => ({ ok: true, arrayBuffer: async () => pdfBytes });
+
+  const result = await getPdfFields('https://example.com/form.pdf');
+  assert.equal(result.success, true);
+  assert.deepEqual(result.fields, ['patient_name']);
+});

--- a/tests/scrape-forms.test.js
+++ b/tests/scrape-forms.test.js
@@ -1,0 +1,22 @@
+import "./setup.js";
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { scrapeRcrForms } from '../test-dist/ai/flows/scrape-forms-flow.js';
+
+const sampleHtml = `
+  <html>
+  <body>
+    <h2>General</h2>
+    <a href="https://example.com/form1.pdf">Form One</a>
+  </body>
+  </html>
+`;
+
+test('scrapeRcrForms extracts a PDF link', async () => {
+  global.fetch = async () => ({ ok: true, text: async () => sampleHtml });
+  const result = await scrapeRcrForms('https://example.com');
+  assert.equal(result.success, true);
+  assert.equal(result.formCount, 1);
+  assert.equal(result.newData[0].category, 'General');
+  assert.equal(result.newData[0].forms[0].title, 'Form One');
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,15 @@
+import Module from 'module';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const originalResolve = Module._resolveFilename;
+Module._resolveFilename = function(request, parent, ...args) {
+  if (request.startsWith('@/')) {
+    const p = path.join(__dirname, '../test-dist', request.slice(2));
+    return originalResolve.call(this, p, parent, ...args);
+  }
+  return originalResolve.call(this, request, parent, ...args);
+};

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./test-dist",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": [
+    "src/ai/flows/get-pdf-fields-flow.ts",
+    "src/ai/flows/scrape-forms-flow.ts",
+    "src/ai/util/cache.ts",
+    "src/lib/types.ts",
+    "src/config/app.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- configure npm `test` script using Node's built-in runner
- add simple unit tests for PDF field extraction and scraping logic
- document `npm test` in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d339814dc83248f52882a76234b15