### PR TITLE
Open PDFs in pre-created browser window

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -378,7 +378,12 @@ export default function Home() {
 
   const handlePdfSubmit = async (finalFormData: Record<string, string>, currentPdfFields?: PdfField[]) => {
     if (!selectedForm) return;
-  
+
+    let pendingWindow: Window | null = null;
+    if (pdfOpenMethodConfig === 'browser') {
+        pendingWindow = window.open('', '_blank');
+    }
+
     setIsSubmitting(true);
   
     // Use passed fields or state fields
@@ -457,9 +462,16 @@ export default function Home() {
             }
         } else {
             // Default to opening in browser
-            window.open(`/api/filled-pdf/${result.pdfId}`, '_blank');
+            if (pendingWindow) {
+                pendingWindow.location.href = `/api/filled-pdf/${result.pdfId}`;
+            } else {
+                window.open(`/api/filled-pdf/${result.pdfId}`, '_blank');
+            }
         }
       } else {
+        if (pendingWindow) {
+            pendingWindow.close();
+        }
         toast({
           variant: 'destructive',
           title: 'PDF Generation Failed',
@@ -467,6 +479,9 @@ export default function Home() {
         });
       }
     } catch (error) {
+      if (pendingWindow) {
+          pendingWindow.close();
+      }
       const errorMessage = error instanceof Error ? error.message : String(error);
       toast({
         variant: 'destructive',


### PR DESCRIPTION
## Summary
- Pre-open a blank window when browser PDF viewing is configured to avoid popup blockers.
- Reuse the pending window for generated PDFs or fall back to a new window if creation fails.
- Close the pending window when PDF generation fails to prevent stranded tabs.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires initial configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6890698dab4c8324affa3b602b24343e