### PR TITLE
Log full KOMS API connection errors

### DIFF
--- a/src/app/api/koms/route.ts
+++ b/src/app/api/koms/route.ts
@@ -95,8 +95,11 @@ export async function GET(req: NextRequest) {
     });
 
   } catch (error) {
-    // Log the full error object to the server console for detailed debugging.
-    console.error('[KOMS_API_ERROR]', error); 
+    // Log the full error object and any nested cause for detailed debugging.
+    console.error('[KOMS_API_ERROR]', error);
+    if (error instanceof Error && error.cause) {
+      console.error('[KOMS_API_ERROR_CAUSE]', error.cause);
+    }
 
     let message = 'An unknown network error occurred';
     if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- Log the full KOMS API error and any nested cause to aid debugging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Requires interactive ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68939771d72c832493c12075f148798f