### PR TITLE
Forward KOMS cookies through auth requests

### DIFF
--- a/src/app/config/admins/page.tsx
+++ b/src/app/config/admins/page.tsx
@@ -32,8 +32,8 @@ export default function AdminsConfigPage() {
       setIsLoading(true);
       try {
         const [userRes, adminsRes] = await Promise.all([
-          fetch('/api/auth/user'),
-          fetch('/api/admins')
+          fetch('/api/auth/user', { credentials: 'include' }),
+          fetch('/api/admins', { credentials: 'include' })
         ]);
 
         if (!userRes.ok) throw new Error('Could not authenticate current user.');
@@ -86,6 +86,7 @@ export default function AdminsConfigPage() {
       const response = await fetch('/api/admins', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify(validAdmins),
       });
 

--- a/src/app/config/page.tsx
+++ b/src/app/config/page.tsx
@@ -67,7 +67,7 @@ export default function ConfigPage() {
   const fetchUserDataAndConfig = async () => {
     setIsLoading(true);
     try {
-        const userRes = await fetch('/api/auth/user');
+        const userRes = await fetch('/api/auth/user', { credentials: 'include' });
         if (!userRes.ok) {
           if (userRes.status === 401) {
             // Not an admin, they should not be here
@@ -80,7 +80,7 @@ export default function ConfigPage() {
         const userData: AdminUser = await userRes.json();
         setCurrentUser(userData);
 
-        const configRes = await fetch('/api/config');
+        const configRes = await fetch('/api/config', { credentials: 'include' });
         if (!configRes.ok) throw new Error('Failed to fetch config');
         const config = await configRes.json();
         
@@ -139,6 +139,7 @@ export default function ConfigPage() {
         headers: {
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
         body: JSON.stringify(updates),
       });
 
@@ -207,7 +208,7 @@ export default function ConfigPage() {
 
   const handleExport = async () => {
     try {
-        const res = await fetch('/api/config/backup');
+        const res = await fetch('/api/config/backup', { credentials: 'include' });
         if (!res.ok) throw new Error('Failed to fetch configuration for export.');
         const data = await res.json();
         
@@ -247,6 +248,7 @@ export default function ConfigPage() {
               const response = await fetch('/api/config/backup', {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
+                  credentials: 'include',
                   body: JSON.stringify(importedData)
               });
               


### PR DESCRIPTION
## Summary
- forward incoming request cookies when calling the KOMS service so `/api/auth/user` identifies the requester
- include `credentials: 'include'` on configuration-related client fetches so browser requests forward their KOMS session

## Testing
- npm run typecheck *(fails: existing errors in src/ai/flows/fill-pdf-flow.ts and src/app/config/staff/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c84cf96fdc8324a7e62a88b9d543c6