### PR TITLE
fix: await cookies before accessing iron-session

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -29,7 +29,8 @@ export async function POST(req: NextRequest) {
     }
     
     // Get session and save data
-    const session = await getIronSession<SessionData>(cookies(), sessionOptions);
+    const cookieStore = await cookies();
+    const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
     session.username = authResult.username;
     session.roles = authResult.roles;
     session.isLoggedIn = true;

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -5,7 +5,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { sessionOptions, SessionData } from '@/lib/auth';
 
 export async function POST(req: NextRequest) {
-  const session = await getIronSession<SessionData>(cookies(), sessionOptions);
+  const cookieStore = await cookies();
+  const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
   session.destroy();
   return NextResponse.json({ message: 'Logged out' });
 }

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -5,7 +5,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { sessionOptions, SessionData } from '@/lib/auth';
 
 export async function GET(req: NextRequest) {
-  const session = await getIronSession<SessionData>(cookies(), sessionOptions);
+  const cookieStore = await cookies();
+  const session = await getIronSession<SessionData>(cookieStore, sessionOptions);
 
   if (session.isLoggedIn !== true) {
     return NextResponse.json({


### PR DESCRIPTION
## Summary
- await cookies() before handing to iron-session so Next.js dynamic API requirements are satisfied
- fix runtime error when destroying sessions during logout

## Testing
- not run (not requested)
