### PR TITLE
refactor: lock config editing for read-only roles

### DIFF
--- a/src/app/config/page.tsx
+++ b/src/app/config/page.tsx
@@ -629,8 +629,7 @@ export default function ConfigPage() {
                             <Download className="mr-2 h-4 w-4" />
                             Export App Settings
                         </Button>
-                        {hasWriteAccess && (
-                            <>
+                        <>
                             <Button variant="outline" onClick={handleImportClick} disabled={!hasWriteAccess}>
                                 <Upload className="mr-2 h-4 w-4" />
                                 Import App Settings
@@ -641,9 +640,9 @@ export default function ConfigPage() {
                                 onChange={handleFileImport}
                                 accept="application/json"
                                 className="hidden"
+                                disabled={!hasWriteAccess}
                             />
-                            </>
-                        )}
+                        </>
                     </CardContent>
                 </Card>
               </>


### PR DESCRIPTION
## Summary
- gate staff/tumour/email config CRUD behind change/full roles and disable inputs for read-only users
- add loading states tied to session when calculating permissions
- keep import/export controls visible but inactive when lacking write access

## Testing
- not run (not requested)
